### PR TITLE
[修正]ヘッダーのトグル、注文履歴の合計金額

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -16,7 +16,8 @@ class Customer < ApplicationRecord
          validates :postal_code, presence: true
          validates :address, presence: true
          validates :phone_number, presence: true
-         validates :is_active, presence: true
+         # validates :is_active, presence: true
+         # ブーリアン型で判別するときはpresencd:trueが必要ない(yu)
 
 
 def update_without_current_password(params, *options)

--- a/app/views/customers/edit.html.erb
+++ b/app/views/customers/edit.html.erb
@@ -9,11 +9,11 @@
         			<tbody>
                 		<tr>
         					<td><%= f.label :氏名 %></td>
-            　　　　　　      <td><%= f.text_field :name_last %><%= f.text_field :name_first %></td>
+                              <td><%= f.text_field :name_last %><%= f.text_field :name_first %></td>
                         </tr>
                         <tr>
         					<td><%= f.label :カナ %></td>
-            　　　　　　      <td><%= f.text_field :name_last_kana %><%= f.text_field :name_first_kana %></td>
+                              <td><%= f.text_field :name_last_kana %><%= f.text_field :name_first_kana %></td>
                         </tr>
             			<tr>
                         	<td><%= f.label :郵便番号 %></td>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
                     <span class="icon-bar"></span>
                 </button>
             </div>
-            <div class="collapse navbar-collapse" id="navbarEexample1">
+            <div class="collapse navbar-collapse" id="navbarEexample">
                 <div class="navbar-right">
                     <ul class="nav navbar-nav" style="color: black;">
                         <!-- Customerがログインしている時 -->

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -24,11 +24,11 @@
                         <td><% order_item.each do |order_item| %>
                             <%= order_item.item.name %><br>
                             <% end %></td>
-                    　　<td>
-                        <% sum = 0 %>
-                        <% order_item.each do |order_item| %>
-                        <% sum += order_item.tax_price %>
-                        <% end %>
+                        <td>
+                          <% sum = 0 %>
+                          <% order_item.each do |order_item| %>
+                            <% sum += order_item.tax_price*order_item.amount %>
+                          <% end %>
                         <%= sum + order.shipping %>円</td>
                         <td><%= order.order_status %></td>
                         <td><%=link_to "表示する", order_path(order), class: 'btn-sm btn-primary' %></td>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -30,7 +30,7 @@
 						<td>
 				    		<% sum = 0 %>
 				            <% @order_item.each do |order_item| %>
-				            <% sum += order_item.tax_price %>
+				            <% sum += order_item.tax_price*order_item.amount %>
 				            <% end %>
 				            <%= sum %>円
 			            </td>
@@ -44,7 +44,7 @@
 						<td>
 				    		<% sum = 0 %>
 				            <% @order_item.each do |order_item| %>
-				            <% sum += order_item.tax_price %>
+				            <% sum += order_item.tax_price*order_item.amount %>
 				            <% end %>
 				            <%= sum + @order.shipping %>円</td>
 					</tr>


### PR DESCRIPTION
レイアウトのアプリケーションをいじって、画面幅が狭いときに出るトグルを正常に機能するように変更
カスタマーの注文履歴の合計金額が商品の単品の値段になっていたのを修正